### PR TITLE
Add additional place suggest details

### DIFF
--- a/lib/google_maps/place.rb
+++ b/lib/google_maps/place.rb
@@ -5,13 +5,17 @@ require File.expand_path('api', __dir__)
 module Google
   module Maps
     class Place
-      attr_reader :text, :html, :keyword, :place_id
+      attr_reader :text, :html, :structured_text, :keyword, :place_id
       alias to_s text
       alias to_html html
 
       def initialize(data, keyword)
         @text = data.description
         @place_id = data.place_id
+        @structured_text = {
+          main: data.structured_formatting&.main_text,
+          secondary: data.structured_formatting&.secondary_text
+        }
         @html = highligh_keywords(data, keyword)
       end
 

--- a/lib/google_maps/place.rb
+++ b/lib/google_maps/place.rb
@@ -16,7 +16,7 @@ module Google
           main: data.structured_formatting&.main_text,
           secondary: data.structured_formatting&.secondary_text
         }
-        @html = highligh_keywords(data, keyword)
+        @html = highlight_keywords(data, keyword)
       end
 
       def self.find(keyword, language = :en)
@@ -26,7 +26,7 @@ module Google
 
       private
 
-      def highligh_keywords(data, keyword)
+      def highlight_keywords(data, keyword)
         keyword = Regexp.escape(keyword)
         matches = Array(keyword.scan(/\w+/))
         html = data.description.dup

--- a/spec/fixtures/den-haag-nl.json
+++ b/spec/fixtures/den-haag-nl.json
@@ -1,165 +1,216 @@
 {
-   "predictions" : [
-      {
-         "description" : "Den Haag, Nederland",
-         "id" : "8c334f7bd9f0476cd8ec7e6bf608fbc578c21929",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CjQrAAAAkSxmx61CGnG4CQ4P1SBUj9GWZXsVfkNgmieaaPLYqStPT1e1qd6HO6h4yn67KeY1EhCwxm8-fj43dt40CTmGsOGsGhSo-OS-7rUIst_jgvU2WVdYdMm9Fg",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Den Haag"
-            },
-            {
-               "offset" : 10,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [ "locality", "political", "geocode" ]
+  "predictions": [
+    {
+      "description": "Den Haag, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJcb2YQi-3xUcREGwejVreAAQ",
+      "reference": "ChIJcb2YQi-3xUcREGwejVreAAQ",
+      "structured_formatting": {
+        "main_text": "Den Haag",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Nederland"
       },
-      {
-         "description" : "Den Haag Centraal, Rivierenbuurt-Noord, Den Haag, Nederland",
-         "id" : "4245ebe240131abcb523708d25d08ebd35178c44",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "ClRKAAAAf3OQkaiVGJDR-UvzuQH89ApGATVVUu0AjLJBoAbY6guUdpaOQBNbho4tSVoGVxv55oKIFP91lNSJF4n0vsSUmT32Dvk_Dxi16plK04L8fiISEHnOEP5FxGttyrnJBWiVY8IaFObwRn4LHx7-p1s6k3LcUAUtdxOe",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Den Haag Centraal"
-            },
-            {
-               "offset" : 19,
-               "value" : "Rivierenbuurt-Noord"
-            },
-            {
-               "offset" : 40,
-               "value" : "Den Haag"
-            },
-            {
-               "offset" : 50,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [
-            "train_station",
-            "transit_station",
-            "train_station",
-            "establishment",
-            "geocode"
-         ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Den Haag"
+        },
+        {
+          "offset": 10,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "locality",
+        "political",
+        "geocode"
+      ]
+    },
+    {
+      "description": "Den Haag Centraal, Koningin Julianaplein, Den Haag, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJv6K4Yhe3xUcRxgdRxELZjvc",
+      "reference": "ChIJv6K4Yhe3xUcRxgdRxELZjvc",
+      "structured_formatting": {
+        "main_text": "Den Haag Centraal",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Koningin Julianaplein, Den Haag, Nederland"
       },
-      {
-         "description" : "Den Haag HS, Huygenspark, Den Haag, Nederland",
-         "id" : "218e5dc5d426220c3a499279ed4f06a3618a273a",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CkQ8AAAAuNCq9fb2JS3Fll7-IBRVcDBUjX9sQqIFAQmH9M32xTd6cwDupew3OCyEx0Nd7MOO6N5OZVlHtinAFZcI1LEieBIQLXIO5I88KrVJ-Au8CwsxexoUDrs6sr5cyIfhuP7ykmdmQmAO7yQ",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Den Haag HS"
-            },
-            {
-               "offset" : 13,
-               "value" : "Huygenspark"
-            },
-            {
-               "offset" : 26,
-               "value" : "Den Haag"
-            },
-            {
-               "offset" : 36,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [
-            "train_station",
-            "transit_station",
-            "train_station",
-            "establishment",
-            "geocode"
-         ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Den Haag Centraal"
+        },
+        {
+          "offset": 19,
+          "value": "Koningin Julianaplein"
+        },
+        {
+          "offset": 42,
+          "value": "Den Haag"
+        },
+        {
+          "offset": 52,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "train_station",
+        "transit_station",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Den Haag HS, Stationsplein, Den Haag, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJj_391R-3xUcRQNIq1S4F2vE",
+      "reference": "ChIJj_391R-3xUcRQNIq1S4F2vE",
+      "structured_formatting": {
+        "main_text": "Den Haag HS",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Stationsplein, Den Haag, Nederland"
       },
-      {
-         "description" : "Den Haag Laan van NOI, Den Haag, Nederland",
-         "id" : "039ff4b6f8713c7e9e5386e426c37495c3b64a8c",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CkQ4AAAAKELBwwjpMi5yCEXEpQdwO4IEY1g4rwrOdR_RuWm8MJ1TYMNIYlcbzjSL5G8WIhreuE_-qdjzBAEB7_OiS2-hnBIQ1RD2I7leiPG2P0RKctpnqBoU1-5tPzOaiAuINbB2qb1oJj-v_kk",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Den Haag Laan van NOI"
-            },
-            {
-               "offset" : 23,
-               "value" : "Den Haag"
-            },
-            {
-               "offset" : 33,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [
-            "train_station",
-            "transit_station",
-            "train_station",
-            "establishment",
-            "geocode"
-         ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Den Haag HS"
+        },
+        {
+          "offset": 13,
+          "value": "Stationsplein"
+        },
+        {
+          "offset": 28,
+          "value": "Den Haag"
+        },
+        {
+          "offset": 38,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "train_station",
+        "transit_station",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Den Haag Centrum, Noordeinde, Den Haag, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJAw_JPjC3xUcR23tn90std3g",
+      "reference": "ChIJAw_JPjC3xUcR23tn90std3g",
+      "structured_formatting": {
+        "main_text": "Den Haag Centrum",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Noordeinde, Den Haag, Nederland"
       },
-      {
-         "description" : "Den Haag Centraal BV, Plaats, Centrum, Den Haag, Nederland",
-         "id" : "e4605c9b3aab6d17c5119270ea06e3edc59fda1a",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "ClRJAAAA6s_C56BY125pwZsIKbiaat7RbuNRU8F0TdmYuyRScosXMNg_kRKjh9uTnMIA8lP5XvGbL7KJqc2PuAXBw3Mvm9ws1bcUUopejRJOIitd1M4SEGl8IwPTeX0_mEj-IwsnyCYaFEyWuAw1rIrxph74gCd8MJb6YgpM",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Den Haag Centraal BV"
-            },
-            {
-               "offset" : 22,
-               "value" : "Plaats"
-            },
-            {
-               "offset" : 30,
-               "value" : "Centrum"
-            },
-            {
-               "offset" : 39,
-               "value" : "Den Haag"
-            },
-            {
-               "offset" : 49,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [ "establishment" ]
-      }
-   ],
-   "status" : "OK"
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Den Haag Centrum"
+        },
+        {
+          "offset": 18,
+          "value": "Noordeinde"
+        },
+        {
+          "offset": 30,
+          "value": "Den Haag"
+        },
+        {
+          "offset": 40,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Den Haag, Centraal Station, Den Haag, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJKYiPYhe3xUcRSPF5Q-AxpM8",
+      "reference": "ChIJKYiPYhe3xUcRSPF5Q-AxpM8",
+      "structured_formatting": {
+        "main_text": "Den Haag, Centraal Station",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Den Haag, Nederland"
+      },
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Den Haag, Centraal Station"
+        },
+        {
+          "offset": 28,
+          "value": "Den Haag"
+        },
+        {
+          "offset": 38,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "transit_station",
+        "point_of_interest",
+        "establishment"
+      ]
+    }
+  ],
+  "status": "OK"
 }

--- a/spec/fixtures/deventer-en.json
+++ b/spec/fixtures/deventer-en.json
@@ -1,139 +1,210 @@
 {
-   "predictions" : [
-      {
-         "description" : "Deventer, The Netherlands",
-         "id" : "843538b8f2308056edb1a8d11d0bed0dcec01087",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CkQxAAAAaSPEKxAHaEMEfXqOiOzsG2eXA-nEhj9moN1WdLGcU5vbbH4xRsyMqxOrWxDOgZZK3TOc2pRtBwizFZsLfPvymxIQwYbT3eljgi1z_OqWP4V5ThoUFP8oWfCjySHtTp8db0USQbLj9Ww",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventer"
-            },
-            {
-               "offset" : 10,
-               "value" : "The Netherlands"
-            }
-         ],
-         "types" : [ "locality", "political", "geocode" ]
+  "predictions": [
+    {
+      "description": "Deventer, Netherlands",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJEVZdr8nrx0cR43GF2RgNpME",
+      "reference": "ChIJEVZdr8nrx0cR43GF2RgNpME",
+      "structured_formatting": {
+        "main_text": "Deventer",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Netherlands"
       },
-      {
-         "description" : "Deventer, MO, United States",
-         "id" : "16066b8ed6f7d40d5c279c13f1b14a68fd133595",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CkQzAAAAO82_HQKci1tiFUdeyxiODVQDyb00SKo6la1sz0YFbACBW8ruj33y3PLUU1IC6I4VOgg4R_qqUtgNsCJPQ6OKRxIQCQxUH8DghtFTQdV0zMa9vxoUOYfsRL4UFY73zAY0PSHMceDxiKw",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventer"
-            },
-            {
-               "offset" : 10,
-               "value" : "MO"
-            },
-            {
-               "offset" : 14,
-               "value" : "United States"
-            }
-         ],
-         "types" : [ "locality", "political", "geocode" ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer"
+        },
+        {
+          "offset": 10,
+          "value": "Netherlands"
+        }
+      ],
+      "types": [
+        "locality",
+        "political",
+        "geocode"
+      ]
+    },
+    {
+      "description": "Deventer Ziekenhuis, Nico Bolkesteinlaan, Deventer, Netherlands",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJ8eFCebbrx0cRFQB9vaxiZSg",
+      "reference": "ChIJ8eFCebbrx0cRFQB9vaxiZSg",
+      "structured_formatting": {
+        "main_text": "Deventer Ziekenhuis",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Nico Bolkesteinlaan, Deventer, Netherlands"
       },
-      {
-         "description" : "Deventer Crescent, Camberwell, United Kingdom",
-         "id" : "7dd097d82375eb159b244aba1a299482c73a3c57",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "ClRFAAAAPM3xLL2EH13DGrXfCsVJKvL8sSJWKs20q7l5f2xW9hzc6zJmaTeCWVlgedRRskKr5r39lgtfKFjJpwqcE_zk7TaDlgKBtopEVHn24ZbR6vkSENl5laX5pxPoEFPePia9ivIaFBdGtxagSTujvSqjcfkLwj-R-Fu2",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventer Crescent"
-            },
-            {
-               "offset" : 19,
-               "value" : "Camberwell"
-            },
-            {
-               "offset" : 31,
-               "value" : "United Kingdom"
-            }
-         ],
-         "types" : [ "route", "geocode" ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer Ziekenhuis"
+        },
+        {
+          "offset": 21,
+          "value": "Nico Bolkesteinlaan"
+        },
+        {
+          "offset": 42,
+          "value": "Deventer"
+        },
+        {
+          "offset": 52,
+          "value": "Netherlands"
+        }
+      ],
+      "types": [
+        "hospital",
+        "health",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Deventerstraat, Apeldoorn, Netherlands",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "EiZEZXZlbnRlcnN0cmFhdCwgQXBlbGRvb3JuLCBOZXRoZXJsYW5kcyIuKiwKFAoSCQOm_2NEx8dHEU-XGayyUFGLEhQKEgnLhxRNKLjHRxGwZR6NWt4ABA",
+      "reference": "EiZEZXZlbnRlcnN0cmFhdCwgQXBlbGRvb3JuLCBOZXRoZXJsYW5kcyIuKiwKFAoSCQOm_2NEx8dHEU-XGayyUFGLEhQKEgnLhxRNKLjHRxGwZR6NWt4ABA",
+      "structured_formatting": {
+        "main_text": "Deventerstraat",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Apeldoorn, Netherlands"
       },
-      {
-         "description" : "Deventer Drive, La Verne, CA, United States",
-         "id" : "95647229cf020ae34b914289ac38684b68f558dd",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "ClRDAAAAkZIQE7lUhLkCBWcwUrWPejMEl2YF4_wDA3n6kZHEE-W6rpU-heR0rtd3Xtq_Fh3bjGp8BlMAcEEwCEdEznB41G2ooVWu8xh5AU8wGSRt2VkSENtalRhpG41HWU_1L1EdV4EaFKVKYYk4BPZH2UYnmsKTZ11cFBtp",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventer Drive"
-            },
-            {
-               "offset" : 16,
-               "value" : "La Verne"
-            },
-            {
-               "offset" : 26,
-               "value" : "CA"
-            },
-            {
-               "offset" : 30,
-               "value" : "United States"
-            }
-         ],
-         "types" : [ "route", "geocode" ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventerstraat"
+        },
+        {
+          "offset": 16,
+          "value": "Apeldoorn"
+        },
+        {
+          "offset": 27,
+          "value": "Netherlands"
+        }
+      ],
+      "types": [
+        "route",
+        "geocode"
+      ]
+    },
+    {
+      "description": "Deventer, Stationsplein, Deventer, Netherlands",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJh2iCd0Lqx0cRmGm1Y7xD1F8",
+      "reference": "ChIJh2iCd0Lqx0cRmGm1Y7xD1F8",
+      "structured_formatting": {
+        "main_text": "Deventer",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Stationsplein, Deventer, Netherlands"
       },
-      {
-         "description" : "VVV Deventer, Pikeursbaan, Deventer, The Netherlands",
-         "id" : "0b00e188d43b6d5da83552aa7154a73270279376",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 4
-            }
-         ],
-         "place_id" : "CmRWAAAA7JnAOFtqLCAaXshQhWqjBC6hUZ1DP-6OGUK0lmt-gT7cxP_RRrlXjIzWgK2rUwcJFcUaibEuiNbj6jReqyiHMrv_VMcMrB3xC2PLMDWFih19nDTwPfU-pULL61yYWjcDEhClXmEG1s7jrEBPFFN76J8xGhStBuODuC9mCXAX5XoGpYHg2OY-sA",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "VVV Deventer"
-            },
-            {
-               "offset" : 14,
-               "value" : "Pikeursbaan"
-            },
-            {
-               "offset" : 27,
-               "value" : "Deventer"
-            },
-            {
-               "offset" : 37,
-               "value" : "The Netherlands"
-            }
-         ],
-         "types" : [ "establishment" ]
-      }
-   ],
-   "status" : "OK"
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer"
+        },
+        {
+          "offset": 10,
+          "value": "Stationsplein"
+        },
+        {
+          "offset": 25,
+          "value": "Deventer"
+        },
+        {
+          "offset": 35,
+          "value": "Netherlands"
+        }
+      ],
+      "types": [
+        "bus_station",
+        "train_station",
+        "transit_station",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Deventerstraatweg, Zwolle, Netherlands",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "EiZEZXZlbnRlcnN0cmFhdHdlZywgWndvbGxlLCBOZXRoZXJsYW5kcyIuKiwKFAoSCRl-63Xf3sdHES9NZYyuTMP6EhQKEgmx7BKdIN_HRxGMPt2SJFsLzQ",
+      "reference": "EiZEZXZlbnRlcnN0cmFhdHdlZywgWndvbGxlLCBOZXRoZXJsYW5kcyIuKiwKFAoSCRl-63Xf3sdHES9NZYyuTMP6EhQKEgmx7BKdIN_HRxGMPt2SJFsLzQ",
+      "structured_formatting": {
+        "main_text": "Deventerstraatweg",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Zwolle, Netherlands"
+      },
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventerstraatweg"
+        },
+        {
+          "offset": 19,
+          "value": "Zwolle"
+        },
+        {
+          "offset": 27,
+          "value": "Netherlands"
+        }
+      ],
+      "types": [
+        "route",
+        "geocode"
+      ]
+    }
+  ],
+  "status": "OK"
 }

--- a/spec/fixtures/deventer-nl-without-structured.json
+++ b/spec/fixtures/deventer-nl-without-structured.json
@@ -1,0 +1,160 @@
+{
+  "predictions": [
+    {
+      "description": "Deventer, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJEVZdr8nrx0cR43GF2RgNpME",
+      "reference": "ChIJEVZdr8nrx0cR43GF2RgNpME",
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer"
+        },
+        {
+          "offset": 10,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "locality",
+        "political",
+        "geocode"
+      ]
+    },
+    {
+      "description": "Deventer Ziekenhuis, Nico Bolkesteinlaan, Deventer, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJ8eFCebbrx0cRFQB9vaxiZSg",
+      "reference": "ChIJ8eFCebbrx0cRFQB9vaxiZSg",
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer Ziekenhuis"
+        },
+        {
+          "offset": 21,
+          "value": "Nico Bolkesteinlaan"
+        },
+        {
+          "offset": 42,
+          "value": "Deventer"
+        },
+        {
+          "offset": 52,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "hospital",
+        "health",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Deventerstraat, Apeldoorn, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "EiREZXZlbnRlcnN0cmFhdCwgQXBlbGRvb3JuLCBOZWRlcmxhbmQiLiosChQKEgkDpv9jRMfHRxFPlxmsslBRixIUChIJy4cUTSi4x0cRsGUejVreAAQ",
+      "reference": "EiREZXZlbnRlcnN0cmFhdCwgQXBlbGRvb3JuLCBOZWRlcmxhbmQiLiosChQKEgkDpv9jRMfHRxFPlxmsslBRixIUChIJy4cUTSi4x0cRsGUejVreAAQ",
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventerstraat"
+        },
+        {
+          "offset": 16,
+          "value": "Apeldoorn"
+        },
+        {
+          "offset": 27,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "route",
+        "geocode"
+      ]
+    },
+    {
+      "description": "Deventer, Stationsplein, Deventer, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJh2iCd0Lqx0cRmGm1Y7xD1F8",
+      "reference": "ChIJh2iCd0Lqx0cRmGm1Y7xD1F8",
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer"
+        },
+        {
+          "offset": 10,
+          "value": "Stationsplein"
+        },
+        {
+          "offset": 25,
+          "value": "Deventer"
+        },
+        {
+          "offset": 35,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "bus_station",
+        "train_station",
+        "transit_station",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Deventerstraatweg, Zwolle, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "EiREZXZlbnRlcnN0cmFhdHdlZywgWndvbGxlLCBOZWRlcmxhbmQiLiosChQKEgkZfut1397HRxEvTWWMrkzD-hIUChIJsewSnSDfx0cRjD7dkiRbC80",
+      "reference": "EiREZXZlbnRlcnN0cmFhdHdlZywgWndvbGxlLCBOZWRlcmxhbmQiLiosChQKEgkZfut1397HRxEvTWWMrkzD-hIUChIJsewSnSDfx0cRjD7dkiRbC80",
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventerstraatweg"
+        },
+        {
+          "offset": 19,
+          "value": "Zwolle"
+        },
+        {
+          "offset": 27,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "route",
+        "geocode"
+      ]
+    }
+  ],
+  "status": "OK"
+}

--- a/spec/fixtures/deventer-nl.json
+++ b/spec/fixtures/deventer-nl.json
@@ -1,135 +1,210 @@
 {
-   "predictions" : [
-      {
-         "description" : "Deventer, Nederland",
-         "id" : "843538b8f2308056edb1a8d11d0bed0dcec01087",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CjQrAAAA6G_H8Wkf0yxyHdXr6p1P4pm3zNs9xByxwFBGZFhWNRvC0QbnUgn2fG8DqcFi4_R0EhD30JBBZ_kAJDdHMO9SO8jQGhSv5Lg5JyOAnjzpgggeVVsgFWecng",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventer"
-            },
-            {
-               "offset" : 10,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [ "locality", "political", "geocode" ]
+  "predictions": [
+    {
+      "description": "Deventer, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJEVZdr8nrx0cR43GF2RgNpME",
+      "reference": "ChIJEVZdr8nrx0cR43GF2RgNpME",
+      "structured_formatting": {
+        "main_text": "Deventer",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Nederland"
       },
-      {
-         "description" : "Deventerstraat, Binnenstad, Apeldoorn, Nederland",
-         "id" : "ccf92f1c2509753b5d5943a45ab9546ce1d6c641",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "ClRIAAAAISW-tYRof6xmWa045VcLdQYcA58uVb4D9P4eEnC8_KpdCMGP62psKHkeYI6qesIAqcjyxZFXfgXSXlmEfC3rImqBMd1SVAamQ27lX5uPu54SEDs3uEeb91yvGtF5Tch4BoMaFMVA3P_5TYTL5yaxgBdZvH0w5IHj",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventerstraat"
-            },
-            {
-               "offset" : 16,
-               "value" : "Binnenstad"
-            },
-            {
-               "offset" : 28,
-               "value" : "Apeldoorn"
-            },
-            {
-               "offset" : 39,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [ "route", "geocode" ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer"
+        },
+        {
+          "offset": 10,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "locality",
+        "political",
+        "geocode"
+      ]
+    },
+    {
+      "description": "Deventer Ziekenhuis, Nico Bolkesteinlaan, Deventer, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJ8eFCebbrx0cRFQB9vaxiZSg",
+      "reference": "ChIJ8eFCebbrx0cRFQB9vaxiZSg",
+      "structured_formatting": {
+        "main_text": "Deventer Ziekenhuis",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Nico Bolkesteinlaan, Deventer, Nederland"
       },
-      {
-         "description" : "Deventerweg, Harderwijk, Nederland",
-         "id" : "28ac3e3713b50ec3474a196a882fc75f23acff0b",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CkQ6AAAAUxuVJkyIyWw7NgDG735TmXMYyNlXxtA15VLI7fU77pF3WZY6zHVDpqTvqa3mF0YThMegF2coDb1UfliapK8RlBIQmLl4iQftD0BRvsPwJO2upxoUOFrlcCHu1SsDRMj8skPQ7x9Sb5Y",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventerweg"
-            },
-            {
-               "offset" : 13,
-               "value" : "Harderwijk"
-            },
-            {
-               "offset" : 25,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [ "route", "geocode" ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer Ziekenhuis"
+        },
+        {
+          "offset": 21,
+          "value": "Nico Bolkesteinlaan"
+        },
+        {
+          "offset": 42,
+          "value": "Deventer"
+        },
+        {
+          "offset": 52,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "hospital",
+        "health",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Deventerstraat, Apeldoorn, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "EiREZXZlbnRlcnN0cmFhdCwgQXBlbGRvb3JuLCBOZWRlcmxhbmQiLiosChQKEgkDpv9jRMfHRxFPlxmsslBRixIUChIJy4cUTSi4x0cRsGUejVreAAQ",
+      "reference": "EiREZXZlbnRlcnN0cmFhdCwgQXBlbGRvb3JuLCBOZWRlcmxhbmQiLiosChQKEgkDpv9jRMfHRxFPlxmsslBRixIUChIJy4cUTSi4x0cRsGUejVreAAQ",
+      "structured_formatting": {
+        "main_text": "Deventerstraat",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Apeldoorn, Nederland"
       },
-      {
-         "description" : "Deventerstraatweg, Zwolle, Nederland",
-         "id" : "f6d0f8176d31842095df09fc777bef63ad7868cb",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CkQ8AAAAcAkp0fKLezWpg_i-S7vDHPr1B37rzFh_LA4ahSbxSAwxDvqy9EEtd1F1UQfapZsCthStQKQLjx-2ft92AboEMBIQjLLTVtJgqrb-3Dx8o_AdJhoUTQeaYO_a6AuxJ1Yqst8chkiPUDY",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventerstraatweg"
-            },
-            {
-               "offset" : 19,
-               "value" : "Zwolle"
-            },
-            {
-               "offset" : 27,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [ "route", "geocode" ]
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventerstraat"
+        },
+        {
+          "offset": 16,
+          "value": "Apeldoorn"
+        },
+        {
+          "offset": 27,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "route",
+        "geocode"
+      ]
+    },
+    {
+      "description": "Deventer, Stationsplein, Deventer, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJh2iCd0Lqx0cRmGm1Y7xD1F8",
+      "reference": "ChIJh2iCd0Lqx0cRmGm1Y7xD1F8",
+      "structured_formatting": {
+        "main_text": "Deventer",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Stationsplein, Deventer, Nederland"
       },
-      {
-         "description" : "Deventerweg, Epse, Nederland",
-         "id" : "1fb8c9e01cc35d1cf9c46629db3320983f2937b3",
-         "matched_substrings" : [
-            {
-               "length" : 8,
-               "offset" : 0
-            }
-         ],
-         "place_id" : "CkQ0AAAA9rpm5apCtZRp0NKvzynbDEhgxVyXL9sEE0XTU3xIj7PvAZlCw8U3zXDjXg6_sePpoV_cJV-BpuJmNihRvHjmWBIQTo1cOfeeqndu6AXy5HLmHxoUU2_zbcs5aVCUUHoPqMkwwkPUE-Y",
-         "terms" : [
-            {
-               "offset" : 0,
-               "value" : "Deventerweg"
-            },
-            {
-               "offset" : 13,
-               "value" : "Epse"
-            },
-            {
-               "offset" : 19,
-               "value" : "Nederland"
-            }
-         ],
-         "types" : [ "route", "geocode" ]
-      }
-   ],
-   "status" : "OK"
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventer"
+        },
+        {
+          "offset": 10,
+          "value": "Stationsplein"
+        },
+        {
+          "offset": 25,
+          "value": "Deventer"
+        },
+        {
+          "offset": 35,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "bus_station",
+        "train_station",
+        "transit_station",
+        "point_of_interest",
+        "establishment"
+      ]
+    },
+    {
+      "description": "Deventerstraatweg, Zwolle, Nederland",
+      "matched_substrings": [
+        {
+          "length": 8,
+          "offset": 0
+        }
+      ],
+      "place_id": "EiREZXZlbnRlcnN0cmFhdHdlZywgWndvbGxlLCBOZWRlcmxhbmQiLiosChQKEgkZfut1397HRxEvTWWMrkzD-hIUChIJsewSnSDfx0cRjD7dkiRbC80",
+      "reference": "EiREZXZlbnRlcnN0cmFhdHdlZywgWndvbGxlLCBOZWRlcmxhbmQiLiosChQKEgkZfut1397HRxEvTWWMrkzD-hIUChIJsewSnSDfx0cRjD7dkiRbC80",
+      "structured_formatting": {
+        "main_text": "Deventerstraatweg",
+        "main_text_matched_substrings": [
+          {
+            "length": 8,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Zwolle, Nederland"
+      },
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Deventerstraatweg"
+        },
+        {
+          "offset": 19,
+          "value": "Zwolle"
+        },
+        {
+          "offset": 27,
+          "value": "Nederland"
+        }
+      ],
+      "types": [
+        "route",
+        "geocode"
+      ]
+    }
+  ],
+  "status": "OK"
 }

--- a/spec/google_maps/place_spec.rb
+++ b/spec/google_maps/place_spec.rb
@@ -21,6 +21,7 @@ describe Google::Maps::Place do
 
         its(:text) { should eq 'Deventer, Nederland' }
         its(:html) { should eq '<strong>Deventer</strong>, Nederland' }
+        its(:structured_text) { should eq(main: 'Deventer', secondary: 'Nederland') }
       end
     end
 
@@ -30,8 +31,9 @@ describe Google::Maps::Place do
       let(:keyword) { 'Deventer' }
       let(:country) { :en }
 
-      its(:text) { should eq 'Deventer, The Netherlands' }
-      its(:html) { should eq '<strong>Deventer</strong>, The Netherlands' }
+      its(:text) { should eq 'Deventer, Netherlands' }
+      its(:html) { should eq '<strong>Deventer</strong>, Netherlands' }
+      its(:structured_text) { should eq(main: 'Deventer', secondary: 'Netherlands') }
     end
 
     context 'only highlights words' do
@@ -42,6 +44,7 @@ describe Google::Maps::Place do
 
       its(:text) { should eq 'Den Haag, Nederland' }
       its(:html) { should eq '<strong>Den</strong> <strong>Haag</strong>, Nederland' }
+      its(:structured_text) { should eq(main: 'Den Haag', secondary: 'Nederland') }
     end
   end
 end

--- a/spec/google_maps/place_spec.rb
+++ b/spec/google_maps/place_spec.rb
@@ -23,6 +23,17 @@ describe Google::Maps::Place do
         its(:html) { should eq '<strong>Deventer</strong>, Nederland' }
         its(:structured_text) { should eq(main: 'Deventer', secondary: 'Nederland') }
       end
+
+      context 'without structured formatting' do
+        before { stub_response('deventer-nl-without-structured.json') }
+
+        let(:keyword) { 'Deventer' }
+        let(:country) { :nl }
+
+        its(:text) { should eq 'Deventer, Nederland' }
+        its(:html) { should eq '<strong>Deventer</strong>, Nederland' }
+        its(:structured_text) { should eq(main: nil, secondary: nil) }
+      end
     end
 
     context ':en' do


### PR DESCRIPTION
![](https://media.giphy.com/media/h2Nj1gsMRbtESyswsw/giphy.gif)

## Context
App boys requested additional fields for responses from the Google Places suggest call. To stay in line with what Google returns, return the `structured_text` property with `main` and `secondary` properties from Gem

## What has been done?
* Updated tests to match real Google Places return data (probably changed over the years)
* Added `structured_text` return object, which returns a hash that has property `main` and `secondary`, which can both be `nil` if not present in the Google response
* Updated tests