### PR TITLE
Add dig to accommodate for properly traversing structured_formatting

### DIFF
--- a/lib/google_maps/place.rb
+++ b/lib/google_maps/place.rb
@@ -13,8 +13,8 @@ module Google
         @text = data.description
         @place_id = data.place_id
         @structured_text = {
-          main: data.structured_formatting&.main_text,
-          secondary: data.structured_formatting&.secondary_text
+          main: data.structured_formatting&.dig(:main_text),
+          secondary: data.structured_formatting&.dig(:secondary_text)
         }
         @html = highlight_keywords(data, keyword)
       end


### PR DESCRIPTION
## Context
When implementing this with mock data in the Reisbalans main repo, I got some errors about not being able to find the `main_text` method. I thought the `&.` would accommodate for this, but apparently doesn't work properly when given a hash.

## Which test failed?
Well this one:

```
        @oude_waelweg =
          Google::Maps::Place.new(
            double(
              description: 'Oude Waelweg, Diemen',
              place_id: 'foo',
              structured_formatting: {
                main_text: 'Oude Waelweg',
                secondary_text: 'Diemen',
              },
            ),
            'Oude Waelweg',
          )
```

## Why is this tested at all in the Reisbalans repo in the first place?
Fair question. What should happen (IMO) is that a JSON mock from the responses from the "external service" (in the context of Reisbalans, the external service is this Google Places gem) should be inserted.

## Then why solve it like this?
I thought: better safe then sorry. This keeps the existing functionality, and also makes passing a hash `structured_formatting` to the `Google::Maps::Place.new` possible.